### PR TITLE
Fix workflow permission issue after Docker build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,10 @@ jobs:
             . poky/oe-init-build-env build && \
             bitbake pitrezor-image && \
             cp tmp/deploy/images/$MACHINE/pitrezor-image-$MACHINE.rpi-sdimg $IMGFILE"
-      
+
+      - name: Restore workspace ownership
+        run: sudo chown -R $(id -u):$(id -g) ${{ github.workspace }}
+
       - name: Create zip archive
         run: |
           TAG="${{ env.BUILD_TAG }}"


### PR DESCRIPTION
### Motivation
- The Dockerized build runs as UID/GID `30000:30000` and leaves `${{ github.workspace }}` owned by that user which can cause host-side steps (notably `zip`) to fail when they try to read/write artifacts.

### Description
- Add a `Restore workspace ownership` step to `.github/workflows/build.yml` immediately after the Docker `bitbake` run which executes `sudo chown -R $(id -u):$(id -g) ${{ github.workspace }}` to reset ownership back to the runner before creating the zip.

### Testing
- Validated the modified workflow parses with Ruby YAML loader using `ruby -e "require 'yaml'; y=YAML.load_file('.github/workflows/build.yml'); puts ['ok', y['name']].join(' ')"` (succeeded) and an attempted Python/PyYAML parse failed due to `PyYAML` not being installed in the environment (environment issue, not a workflow change failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997cf1d8c4c8322b5eb74230ce2cca6)